### PR TITLE
Instructions updated to clarify the Network Watcher part.

### DIFF
--- a/docs/04_secure_your_workloads/04_05.md
+++ b/docs/04_secure_your_workloads/04_05.md
@@ -170,7 +170,11 @@ The key tasks are as follows:
 
     ![Adding a rule to the Firewall Policy.](../../resources/images/lab04_05_AddingDenyRuleCollection.png "Rule Collection and Rule")
 
-Click **Add**
+1. Click **Add**
+
+In order to test your setup, you can use the Connection Troubleshooting tool of **Network Watcher**. 
+
+1. Use the "Search resources, services and docs" at the top of your Azure Portal windows to locate **Network Watcher** 
 
 1. Under **Network diagnostic tools**, select **Connection troubleshoot**
 


### PR DESCRIPTION
i added some more description as the original instructions were missing something or were based on older UI. after adding the rule collection there is no "connection troubleshooting" but rather one needs to navigate to network watcher to have this. 