### PR TITLE
exercise 4 breaks arc communcation, added note to inform and suggest steps to re-enable it, if perticipants want. 

### DIFF
--- a/docs/04_secure_your_workloads/04_05.md
+++ b/docs/04_secure_your_workloads/04_05.md
@@ -196,4 +196,6 @@ Congratulations! You have successfully used the Azure Firewall to remove outgoin
 
 A quick test would be to try and SSH to the public address of the `terrafirm-onprem-workload-vm` which should fail and then try and access it via the Bastion host - which will succeed.
 
+**NOTE** : Once you have successfully completed the creation of the Firewall Rule (see above), all outbound traffic to the internet is blocked. This also includes the traffic necessary for the Azure Arc agent you deployed in exercise 3, so after some time your Arc resource in Azure Portal will show "Disconnected" as the status. If you want to re-enable this, you need to create a firewall rule that allows traffic to the endpoints listed in the Azure Arc Network Requirements documentation or create a rule that allows traffic to the AzureCloud service tag. 
+
 </details>


### PR DESCRIPTION
once a user completes exercise 4 (azure firewall) the required arc traffic is blocked and hence arc will show "disconnected". added a note at the end to suggest options to re-enable the traffic. 

alternatively one could creating the respective rules part of the overall exercise. 